### PR TITLE
fix(domain): rename Order.lineItems to lineitems for Quarkus 3.37 Jackson codegen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ OpenAPI UI is available at `/q/swagger-ui` in dev mode.
 ### Domain Model
 
 - **`Product`** — id, name, description, price (extends `BaseProduct`)
-- **`Order`** — id, date, lineItems, total; requires non-empty `lineItems`
+- **`Order`** — id, date, lineitems, total; requires non-empty `lineitems`
 - **`LineItem`** — references a product with quantity
 - **`Config`** — currency, paymentPresets, labels (UI strings)
 - **`OrderStatistics`** / **`ProductStatistics`** — aggregated reporting data

--- a/src/main/kotlin/de/mkallfass/makspos/domain/Order.kt
+++ b/src/main/kotlin/de/mkallfass/makspos/domain/Order.kt
@@ -23,8 +23,7 @@ data class Order(
     @Schema(name = "lineitems", description = "The lineitems of the order")
     @Valid
     @NotEmpty
-    @field:JsonProperty("lineitems")
-    var lineItems: List<LineItem>,
+    var lineitems: List<LineItem>,
 
     @Schema(name = "total", description = "The total price of the order")
     @field:JsonProperty("total")

--- a/src/main/kotlin/de/mkallfass/makspos/service/OrderService.kt
+++ b/src/main/kotlin/de/mkallfass/makspos/service/OrderService.kt
@@ -51,7 +51,7 @@ class OrderService {
         order.date = ZonedDateTime.now()
 
         var orderTotal = 0.0
-        for (i in order.lineItems) {
+        for (i in order.lineitems) {
             val p = productService.getProductById(i.id)
             if (p != null) {
                 if (i.name != null && i.name != p.name) {
@@ -80,7 +80,7 @@ class OrderService {
     }
 
     private fun calculateProductStatistics(order: Order, productStatistics: ArrayList<ProductStatistics>) {
-        for (lineitem in order.lineItems) {
+        for (lineitem in order.lineitems) {
             var statistics = productStatistics.find { it.id == lineitem.id }
             if (statistics == null) {
                 // Try to create statistics from product repository

--- a/src/test/kotlin/de/mkallfass/makspos/rest/endpoint/OrdersTest.kt
+++ b/src/test/kotlin/de/mkallfass/makspos/rest/endpoint/OrdersTest.kt
@@ -12,14 +12,14 @@ import org.junit.jupiter.api.Test
 class OrdersTest {
     @Test
     fun testOrdersEndpoint() {
-        val lineItems = listOf(
+        val lineitems = listOf(
             LineItem(id = "TEST-01", quantity = 4.5),
             LineItem(id = "TEST-02", quantity = 4.5)
         )
         // @formatter:off
         given()
             .contentType(ContentType.JSON)
-            .body(Order(lineItems = lineItems))
+            .body(Order(lineitems = lineitems))
         .`when`()
             .post("/api/orders")
         .then()


### PR DESCRIPTION
## Summary
- Quarkus 3.37 ships a reflection-free Jackson deserializer for Kotlin data classes (`Order$quarkusjacksondeserializer`) that binds JSON keys to constructor parameter names and ignores `@field:JsonProperty`.
- Constructor parameter `lineItems` + `@field:JsonProperty("lineitems")` therefore no longer matched the incoming JSON key `lineitems`; the non-null parameter received `null` and the constructor threw NPE on `POST /api/orders` (500).
- Renames the Kotlin property to `lineitems` to match the JSON contract the webui already uses; drops the now-redundant `@field:JsonProperty`.

Unblocks #658 (Quarkus 3.36.3 → 3.37.0 bump) — once this lands, Dependabot rebases and CI on that PR turns green.

## Test plan
- [x] `./mvnw test -Dquinoa.skip=true` — `OrdersTest` + `ProductsTest` both green locally on Quarkus 3.36.3 (current `develop`).
- [ ] CI on Quarkus 3.36.3 (this PR)
- [ ] CI on Quarkus 3.37.0 (after #658 rebase)

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)